### PR TITLE
Add serverless redirect to other workshop

### DIFF
--- a/workshop/content/030_basic_content/075_serverless/_index.md
+++ b/workshop/content/030_basic_content/075_serverless/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Serverless"
+chapter: false
+weight: 75
+---
+
+FIS currently does not support disrupting serverless execution in AWS Lambda. It is, however, possible to inject chaos actions by decorating the code executed within AWS Lambda. For a deeper introduction to the topic see the [Serverless Chaos workshop](https://resilience.workshop.aws/).


### PR DESCRIPTION
*Issue #, if available:* fixes #120

*Description of changes:*

* Added a single page to say that FIS doesn't support Lambda directly but to explore serverless chaos workshop for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
