### PR TITLE
Trivially fix graph names to remove goad

### DIFF
--- a/workshop/content/030_basic_content/020_working_under_load/_index.en.md
+++ b/workshop/content/030_basic_content/020_working_under_load/_index.en.md
@@ -76,7 +76,7 @@ That's odd, did anything happen? According to nginx we would think nothing happe
 
 {{< img "dashboard-extended-home.en.png" "Load against home page" >}}
 
-Now it's more clear what happened: we were requesting a small static page and nginx is incredibly efficient. In the `server cpu` graph we can see minimal CPU utilization at the same time as the load data in the `goad` graphs. 
+Now it's more clear what happened: we were requesting a small static page and nginx is incredibly efficient. In the `Server CPU` graph we can see minimal CPU utilization at the same time as the load data in the `Customer (load test)` graphs. 
 
 ## Increasing the load
 


### PR DESCRIPTION
*Issue #, if available:* fixes #131

*Description of changes:*

* Don't want to break anything so only changing graph names in 30/20 but leaving the custom metric name (somewhat visible to users) and the stack names (mostly invisible to users).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
