### PR TITLE
Add class tag and menu highlight for draft elements

### DIFF
--- a/workshop/themes/learn/layouts/partials/menu.html
+++ b/workshop/themes/learn/layouts/partials/menu.html
@@ -101,6 +101,7 @@
         {{if .IsAncestor $currentNode }}parent{{end}}
         {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}
         {{if .Params.alwaysopen}}parent{{end}}
+        {{if .Params.draft}}draft{{end}}
         ">
       <a href="{{.RelPermalink}}">
           {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}

--- a/workshop/themes/learn/static/css/theme-aws.css
+++ b/workshop/themes/learn/static/css/theme-aws.css
@@ -184,6 +184,8 @@ a:hover {
     color: #e07d04 !important;
 }
 
+#sidebar li.draft { background-color: rgba(216, 129, 23, 0.673); }
+
 div.notices p:first-child:before {
     position: absolute;
     top: 2px;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To help with editing with hugo in draft mode `hugo -D` this patch will add a `draft` class to menu items for any pages with `draft = true` in front matter. This helps as a reminder to fix the draft status before committing a pull request and it helps with debugging situations where we think something should be visible on the prod site but it isn't because it's still in draft status.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
