### PR TITLE
feature(eks) Configure log retention #217

### DIFF
--- a/resources/templates/eks/package.json
+++ b/resources/templates/eks/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@aws-cdk/aws-ec2": "^1.123.0",
     "@aws-cdk/aws-eks": "^1.123.0",
+    "@aws-cdk/aws-lambda": "^1.123.0",
+    "@aws-cdk/aws-logs": "^1.123.0",
     "@aws-cdk/core": "1.123.0",
     "source-map-support": "^0.5.20"
   }


### PR DESCRIPTION
Issue #217 , if available: 217

Description of changes: Added an Aspect that will walk the tree of resources that the ekscluster construct creates and precreate log groups for each lambda Function it finds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
