### PR TITLE
Update ca certs to allow https package downloads

### DIFF
--- a/resources/templates/goad-cdk/lib/goad-cdk-test-stack.ts
+++ b/resources/templates/goad-cdk/lib/goad-cdk-test-stack.ts
@@ -11,9 +11,12 @@ export class GoadCdkTestStack extends cdk.Stack {
       runtime: lambda.Runtime.GO_1_X,
       code: lambda.Code.fromAsset('load-gen',{
         bundling: {
+          // lambci/lambda:build-go1.x
           image: lambda.Runtime.GO_1_X.bundlingImage,
           command: [
             'bash', '-xc', [
+              // looks like the ca certs are a bit too old by default
+              'yum install -y ca-certificates',
               'pwd',
               'ls /',
               // 'export GOPATH=/asset-output',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* GO was failing to pull packages because it thought the SSL certs were invalid. Updating the certs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
