### PR TITLE
Improve deploy scripts

### DIFF
--- a/resources/code/cdk/cicd/deploy.sh
+++ b/resources/code/cdk/cicd/deploy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+echo "Provisioning optional CiCd resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy CicdStack --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt

--- a/resources/templates/.gitignore
+++ b/resources/templates/.gitignore
@@ -1,3 +1,4 @@
 deploy-output*
 cleanup-output*
 deploy-status.txt
+cleanup-status.txt

--- a/resources/templates/api-failures/cleanup.sh
+++ b/resources/templates/api-failures/cleanup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+echo "Cleaning up API fault resources"
+echo "FAIL" > cleanup-status.txt
+
+# Check if stack exists in some sort of deletable state
+STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisApiFailureUnavailable')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
+if [ -n "${STACK_NAME}" ]; then
+    echo "... deleting FisApiFailureUnavailable"
+    aws cloudformation delete-stack \
+        --stack-name FisApiFailureUnavailable
+    aws cloudformation wait stack-delete-complete \
+        --stack-name FisApiFailureUnavailable
+else
+    echo "... no deletable FisApiFailureUnavailable stack found, skipping"
+fi
+
+# Check if stack exists in some sort of deletable state
+STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisApiFailureThrottling')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
+if [ -n "${STACK_NAME}" ]; then
+    echo "... deleting FisApiFailureThrottling"
+    aws cloudformation delete-stack \
+        --stack-name FisApiFailureThrottling
+    aws cloudformation wait stack-delete-complete \
+        --stack-name FisApiFailureThrottling
+else
+    echo "... no deletable FisApiFailureThrottling stack found, skipping"
+fi
+
+echo "OK" > cleanup-status.txt

--- a/resources/templates/api-failures/deploy.sh
+++ b/resources/templates/api-failures/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Provisioning API failure stacks"
+
+echo "FAIL" > deploy-status.txt
+
+# Query public subnet from VPC stack
+SUBNET_ID=$( aws ec2 describe-subnets --query "Subnets[?Tags[?(Key=='aws-cdk:subnet-name') && (Value=='FisPub') ]] | [0].SubnetId" --output text )
+
+# Launch CloudFormation stack
+echo "... FisApiFailureThrottling"
+aws cloudformation deploy \
+    --stack-name FisApiFailureThrottling \
+    --template-file api-throttling.yaml  \
+    --capabilities CAPABILITY_IAM
+
+echo "... FisApiFailureUnavailable"
+aws cloudformation deploy \
+    --stack-name FisApiFailureUnavailable \
+    --template-file api-unavailable.yaml  \
+    --parameter-overrides \
+        SubnetId=${SUBNET_ID} \
+    --capabilities CAPABILITY_IAM
+
+echo "OK" > deploy-status.txt

--- a/resources/templates/api-failures/deploy.sh
+++ b/resources/templates/api-failures/deploy.sh
@@ -12,6 +12,7 @@ echo "... FisApiFailureThrottling"
 aws cloudformation deploy \
     --stack-name FisApiFailureThrottling \
     --template-file api-throttling.yaml  \
+    --no-fail-on-empty-changeset \
     --capabilities CAPABILITY_IAM
 
 echo "... FisApiFailureUnavailable"
@@ -20,6 +21,7 @@ aws cloudformation deploy \
     --template-file api-unavailable.yaml  \
     --parameter-overrides \
         SubnetId=${SUBNET_ID} \
+    --no-fail-on-empty-changeset \
     --capabilities CAPABILITY_IAM
 
 echo "OK" > deploy-status.txt

--- a/resources/templates/api-failures/deploy.sh
+++ b/resources/templates/api-failures/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning API failure stacks"
 
 echo "FAIL" > deploy-status.txt

--- a/resources/templates/asg-cdk/cleanup.sh
+++ b/resources/templates/asg-cdk/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Cleaning up ASG resources"
+echo "FAIL" > cleanup-status.txt
+npm install
+npx cdk destroy FisStackAsg --force
+echo "OK" > cleanup-status.txt
+

--- a/resources/templates/asg-cdk/deploy.sh
+++ b/resources/templates/asg-cdk/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning ASG resources"
 echo "FAIL" > deploy-status.txt
 npm install

--- a/resources/templates/asg-cdk/deploy.sh
+++ b/resources/templates/asg-cdk/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Provisioning ASG resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy FisStackAsg --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt

--- a/resources/templates/cleanup-parallel.sh
+++ b/resources/templates/cleanup-parallel.sh
@@ -10,166 +10,57 @@ ACCOUNT_ID=$(aws sts get-caller-identity --output text --query 'Account')
 echo "Cleanup in AWS Account: ${ACCOUNT_ID}"
 echo "Cleanup in Region: ${REGION}"
 
+function call_cleanup_script() {
+    INSTALLER_DIR=$1
+    INSTALLER_NAME=$(echo ${INSTALLER_DIR} | sed -e 's/[^a-zA-Z0-9]/-/g; s/^-*//; s/-*$//' )
+    INSTALLER_COMMENT=$2
+    echo "Cleanup from ${INSTALLER_DIR}: ${INSTALLER_COMMENT}"
+    (
+        cd ${INSTALLER_DIR}
+        bash cleanup.sh
+    ) > cleanup-output.${INSTALLER_NAME}.txt 2>&1 &
+}
+
+# Clean up previous cleanup record
+rm -f cleanup-output.*.txt */cleanup-status.txt
+
 # Optional demo infrastructure stack used in the CiCd lab
 # This stack uses IAM role from the Cicd stack: it must be deleted before starting the deletion of the Cicd stack
-(
-    STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='fisWorkshopDemo')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-    if [ -n "${STACK_NAME}" ]; then
-        echo "Deleting demo infrastructure stack used in the CiCd lab"
-
-        # Delete CloudFormation stack
-        aws cloudformation delete-stack \
-        --stack-name fisWorkshopDemo
-        aws cloudformation wait stack-delete-complete \
-        --stack-name fisWorkshopDemo
-    else
-        echo "Demo infrastructure stack used in the CiCd lab not found"
-    fi
-)
-
-# Optional CiCd stack
-STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='CicdStack')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-if [ -n "${STACK_NAME}" ]; then
-    echo "Deleting optional CiCd stack"
-    (
-        cd cpu-stress
-
-        # Delete CloudFormation stack
-        aws cloudformation delete-stack \
-        --stack-name CicdStack
-        aws cloudformation wait stack-delete-complete \
-        --stack-name CicdStack
-    ) > cleanup-output.cicd.txt 2>&1 &
-else
-    echo "Optional CiCd stack stack not found"
-fi
-
-# Optional CpuStress stack
-STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='CpuStress')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-if [ -n "${STACK_NAME}" ]; then
-    echo "Deleting optional CpuStress stack"
-    (
-        cd cpu-stress
-
-        # Delete CloudFormation stack
-        aws cloudformation delete-stack \
-        --stack-name CpuStress
-        aws cloudformation wait stack-delete-complete \
-        --stack-name CpuStress
-    ) > cleanup-output.stressopt.txt 2>&1 &
-else
-    echo "Optional CpuStress stack stack not found"
-fi
-
-# Spot stack added as SAM
-STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisSpotTest')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-if [ -n "${STACK_NAME}" ]; then
-    echo "Deleting Spot stack"
-    (
-        cd spot
-        bash cleanup.sh
-    ) > cleanup-output.spot.txt 2>&1 &
-else
-    echo "Spot test stack not found"
-fi
+call_cleanup_script "../code/cdk/cicd/" "Optional CiCd stack" 
 
 # Stress VM stack added as CFN
-STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisCpuStress')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-if [ -n "${STACK_NAME}" ]; then
-    echo "Deleting CPU stress instances"
-    (
-        cd cpu-stress
+call_cleanup_script "cpu-stress" "CPU stress stack" 
 
-        # Delete CloudFormation stack
-        aws cloudformation delete-stack \
-        --stack-name FisCpuStress
-        aws cloudformation wait stack-delete-complete \
-        --stack-name FisCpuStress
-    ) > cleanup-output.stress.txt 2>&1 &
-else
-    echo "CPU stress stack not found"
-fi
+# Spot stack added as SAM
+call_cleanup_script "spot" "Spot stack" 
 
 # Fault stacks added as CFN
-STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisApiFailureUnavailable')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-if [ -n "${STACK_NAME}" ]; then
-    echo "Deleting API faulrt injections stack FisApiFailureUnavailable"
-    (
-        # Delete CloudFormation stack
-        aws cloudformation delete-stack \
-        --stack-name FisApiFailureUnavailable
-        aws cloudformation wait stack-delete-complete \
-        --stack-name FisApiFailureUnavailable
-    ) > cleanup-output.api-unavailable.txt 2>&1 &
-else
-    echo "API fault injection stack FisApiFailureUnavailable not found"
-fi
-
-STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisApiFailureThrottling')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
-if [ -n "${STACK_NAME}" ]; then
-    echo "Deleting API faulrt injections stack FisApiFailureThrottling"
-
-    (    # Delete CloudFormation stack
-        aws cloudformation delete-stack \
-        --stack-name FisApiFailureThrottling
-        aws cloudformation wait stack-delete-complete \
-        --stack-name FisApiFailureThrottling
-    )  > cleanup-output.api-throttling.txt 2>&1 &
-else
-    echo "API fault injection stack FisApiFailureThrottling not found"
-fi
-
+call_cleanup_script "api-failures" "API failure stacks" 
 
 
 
 # ECS using CDK
-echo "Deleting ECS..."
-(
-    cd ecs
-    npx cdk destroy FisStackEcs --force
-) > cleanup-output.ecs.txt 2>&1 &
+call_cleanup_script "ecs" "ECS stack" 
 
 # EKS using CDK
-echo "Deleting EKS..."
-(
-    cd eks
-    npx cdk destroy FisStackEks --force
-) > cleanup-output.eks.txt 2>&1 &
+call_cleanup_script "eks" "EKS stack" 
 
 # ASG stack moved to CDK
-echo "Deleting EC2 Autoscaling Group..."
-(
-    cd asg-cdk
-    npx cdk destroy FisStackAsg --force
-) > cleanup-output.asg.txt 2>&1 &
+call_cleanup_script "asg-cdk" "ASG stack" 
 
 # RDS/aurora stack uses CDK
-echo "Deleting RDS..."
-(
-    cd rds
-    npm install
-    npx cdk destroy FisStackRdsAurora --force
-) > cleanup-output.rds.txt 2>&1 &
+call_cleanup_script "rds" "RDS stack" 
 
 # Goad stack moved to CDK
+call_cleanup_script "goad-cdk" "Load generator (goad) stack" 
 echo "Deleting Load Generator..."
-(
-    cd goad-cdk
-    npm install
-    npx cdk destroy --force
-) > cleanup-output.goad.txt 2>&1 &
 
 # Wait before deleting VPC
 echo "Waiting before starting VPC deletion"
 wait
 
 # VPC stack uses CDK
-echo "Deleting VPC..."
-(
-    cd vpc
-    npm install
-    npx cdk destroy FisStackVpc --force
-) > cleanup-output.vpc.txt 2>&1 &
+call_cleanup_script "vpc" "VPC stack" 
 
 # Delete log groups because they break future deployments
 echo "Deleting log groups ..."
@@ -196,4 +87,32 @@ echo "Deleting cdk state files ..."
 echo "Waiting for finish"
 wait
 
-echo Done.
+EXIT_STATUS=0
+for substack in \
+    ../code/cdk/cicd \
+    vpc \
+    goad-cdk \
+    rds \
+    asg-cdk \
+    eks \
+    ecs \
+    cpu-stress \
+    api-failures \
+    spot \
+; do
+    touch $substack/cleanup-status.txt
+    RES=$(cat $substack/cleanup-status.txt)
+    if [ "$RES" != "OK" ]; then
+        echo "Substack $substack FAILED"
+        EXIT_STATUS=1
+    else
+        echo "Substack $substack SUCCEEDED"
+    fi
+done
+
+if [ ${EXIT_STATUS:=1} -eq 1 ]; then
+    echo "Overall cleanup FAILED"
+else
+    echo "Overall cleanup SUCCEEDED"
+fi
+exit $EXIT_STATUS

--- a/resources/templates/cpu-stress/cleanup.sh
+++ b/resources/templates/cpu-stress/cleanup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Cleaning up CPU stress resources"
+echo "FAIL" > cleanup-status.txt
+
+# Check if stack exists in some sort of deletable state
+STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisCpuStress')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
+if [ -n "${STACK_NAME}" ]; then
+    echo "... deleting"
+    aws cloudformation delete-stack \
+        --stack-name FisCpuStress
+    aws cloudformation wait stack-delete-complete \
+        --stack-name FisCpuStress
+else
+    echo "... no deletable stack found, skipping"
+fi
+
+echo "OK" > cleanup-status.txt

--- a/resources/templates/cpu-stress/deploy.sh
+++ b/resources/templates/cpu-stress/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Provisioning CPU stress instances"
+echo "FAIL" > deploy-status.txt
+
+# Query public subnet from VPC stack
+SUBNET_ID=$( aws ec2 describe-subnets --query "Subnets[?Tags[?(Key=='aws-cdk:subnet-name') && (Value=='FisPub') ]] | [0].SubnetId" --output text )
+
+# Launch CloudFormation stack
+aws cloudformation deploy \
+    --stack-name FisCpuStress \
+    --template-file CPUStressInstances.yaml  \
+    --parameter-overrides \
+        SubnetId=${SUBNET_ID} \
+    --no-fail-on-empty-changeset \
+    --capabilities CAPABILITY_IAM
+
+echo "OK" > deploy-status.txt

--- a/resources/templates/cpu-stress/deploy.sh
+++ b/resources/templates/cpu-stress/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning CPU stress instances"
 echo "FAIL" > deploy-status.txt
 

--- a/resources/templates/deploy-ee-codebuild/debug.sh
+++ b/resources/templates/deploy-ee-codebuild/debug.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+AWS_ACCOUNT=$( aws sts get-caller-identity --query 'Account' --output text )
+
+echo "Exporting cloudformation stacks that were created and their state"
+aws cloudformation list-stacks > ee-debug.${AWS_ACCOUNT}.stacks.txt
+
+echo "Exporting codebuild history"
+LOG_GROUPS=$( aws logs describe-log-groups --log-group-name-prefix /aws/codebuild/ --query 'logGroups[*].logGroupName' --output text )
+for ii in ${LOG_GROUPS}; do
+  LOG_STREAMS=$( aws logs describe-log-streams --log-group-name ${ii} --query 'logStreams[*].logStreamName' --output text )
+  for jj in ${LOG_STREAMS}; do
+    echo === ${ii} === ${jj} ===
+    echo === ${ii} === ${jj} === >> ee-debug.${AWS_ACCOUNT}.codebuild.txt
+    aws logs get-log-events --log-group-name ${ii} --log-stream-name ${jj} >> ee-debug.${AWS_ACCOUNT}.codebuild.txt 2>&1 
+  done
+done

--- a/resources/templates/deploy-ee-codebuild/template.yaml
+++ b/resources/templates/deploy-ee-codebuild/template.yaml
@@ -1,13 +1,14 @@
 Resources:
-  # FisWorkshopBuilderCustomResource:
-  MyCustomResource:
+  WorkshopBuilderCustomResource:
     Type: 'Custom::CdkInstallWrapper'
+    DependsOn: CustomResourceLambda
     Properties:
       ServiceToken: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${CustomResourceLambda}"
       CodeBuildProjectName: !Ref CodeBuildProject
       ForceUpdateParam: 1
   CustomResourceLambda:
     Type: AWS::Lambda::Function
+    DependsOn: CodeBuildProject
     Properties:
       Runtime: nodejs12.x
       Role: !GetAtt CustomLambdaRole.Arn
@@ -19,14 +20,14 @@ Resources:
           exports.handler = function(event, context) {
               console.log("REQUEST RECEIVED:\n" + JSON.stringify(event))
 
-              // For Delete requests, immediately send a SUCCESS response.\
+              // For Delete requests, immediately send a SUCCESS response.
+              // We never try to "delete" the stacks / codebuild, we leave that to EE reapers
               if (event.RequestType == "Delete") {
                   response.send(event, context, "SUCCESS")
                   return
               }
 
-              // FIXME: this kicks off the codebuild but can't wait to finish because max lambda runtime is 15min. Maybe this should be wrapped into step functions?
-              var codebuild = new aws.CodeBuild();
+              // pass custom resource invocation params to codebuild
               var params={
                 projectName: event.ResourceProperties.CodeBuildProjectName,
                 environmentVariablesOverride: [
@@ -58,19 +59,26 @@ Resources:
                 ],
               };
               console.log("Parameters: " + JSON.stringify(params))
+
+              // Kick off codebuild. Note that this lambda will never
+              // return success because the codebuild time can 
+              // exceed 15min. Instead the loop will close with a 
+              // success message from codebuild or the 1h timeout
+              // for custom resources.
+              var codebuild = new aws.CodeBuild();
               codebuild.startBuild(params, function(err, data) {
                 if (err) {
                   // an error occurred - tell CFN immediately
                   console.log(err, err.stack); 
                   response.send(event, context, "FAILED");
                 } else {
-                    // successfully started codpipeline
-                    // success signal will come from CodeBuild job
-                    console.log(data);           
+                  // successfully started codpipeline
+                  // success signal will come from CodeBuild job
+                  console.log(data);           
                 }
               });
 
-              // Remove this ... we close the loop in CodeBuild
+              // Do NOT send success ... we close the loop in CodeBuild
               //response.send(event, context, "SUCCESS")
               return
           }
@@ -85,27 +93,15 @@ Resources:
         # Type: CODEPIPELINE
         Type: NO_ARTIFACTS
       Environment:
+        # Pick a container type and size
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL
-        # By default codebuild doesn't allow docker in docker
-        # There seems to be an option of running docker in docker
-        # but is that a good idea ... ?
-        # https://docs.aws.amazon.com/codebuild/latest/userguide/sample-docker-custom-image.html
-        PrivilegedMode: True
-        #
-        # Image: aws/codebuild/ubuntu-base:14.04
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-        # EnvironmentVariables:
-        #   - Name: varName1
-        #     Value: varValue1
-        #   - Name: varName2
-        #     Value: varValue2
-        #     Type: PLAINTEXT
-        #   - Name: varName3
-        #     Value: /CodeBuild/testParameter
-        #     Type: PARAMETER_STORE
+        # Enable set this to true if you need docker in docker builds,
+        # e.g. for Golang lambda deployments from CDK
+        PrivilegedMode: True
       Source:
-        # Type: CODEPIPELINE
+        # We let the script pull code from GitHub or S3
         Type: NO_SOURCE
         BuildSpec: |
           version: 0.2
@@ -153,13 +149,6 @@ Resources:
                 - "curl  -H 'Content-Type: ''' -X PUT -d '{ \"Status\": \"'${CUSTOM_RESOURCE_STATUS}'\", \"PhysicalResourceId\": \"'${CUSTOM_RESOURCE_PHYSICAL_RESOURCE_ID}'\", \"StackId\": \"'${CUSTOM_RESOURCE_STACK_ID}'\", \"RequestId\": \"'${CUSTOM_RESOURCE_REQUEST_ID}'\", \"LogicalResourceId\": \"'${CUSTOM_RESOURCE_LOGICAL_RESOURCE_ID}'\" }' ${CUSTOM_RESOURCE_RESPONSE_URL}"
   
       TimeoutInMinutes: 60
-      # VpcConfig:
-      #   VpcId: !Ref CodeBuildVPC
-      #   Subnets: [!Ref CodeBuildSubnet]
-      #   SecurityGroupIds: [!Ref CodeBuildSecurityGroup]
-      # Cache:
-      #   Type: S3
-      #   Location: mybucket/prefix
   CustomLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -186,41 +175,3 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
-      # Policies:
-      #   - PolicyName: CodeBuildAccess
-      #     PolicyDocument:
-      #       Version: '2012-10-17'
-      #       Statement:
-      #         - Action:
-      #           - 'logs:*'
-      #           - 'ec2:CreateNetworkInterface'
-      #           - 'ec2:DescribeNetworkInterfaces'
-      #           - 'ec2:DeleteNetworkInterface'
-      #           - 'ec2:DescribeSubnets'
-      #           - 'ec2:DescribeSecurityGroups'
-      #           - 'ec2:DescribeDhcpOptions'
-      #           - 'ec2:DescribeVpcs'
-      #           - 'ec2:CreateNetworkInterfacePermission'
-      #           Effect: Allow
-      #           Resource: '*'
-  # CodeBuildVPC:
-  #   Type: AWS::EC2::VPC
-  #   Properties:
-  #     CidrBlock: 10.0.0.0/16
-  #     EnableDnsSupport: 'true'
-  #     EnableDnsHostnames: 'true'
-  #     Tags:
-  #       - Key: name
-  #         Value: codebuild
-  # CodeBuildSubnet:
-  #   Type: AWS::EC2::Subnet
-  #   Properties:
-  #     VpcId:
-  #       Ref: CodeBuildVPC
-  #     CidrBlock: 10.0.1.0/24
-  # CodeBuildSecurityGroup:
-  #   Type: AWS::EC2::SecurityGroup
-  #   Properties:
-  #     GroupName: Codebuild Internet Group
-  #     GroupDescription: 'CodeBuild SecurityGroup'
-  #     VpcId: !Ref CodeBuildVPC

--- a/resources/templates/ecs/cleanup.sh
+++ b/resources/templates/ecs/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Cleaning up ECS resources"
+echo "FAIL" > cleanup-status.txt
+npm install
+npx cdk destroy FisStackEcs --force
+echo "OK" > cleanup-status.txt
+

--- a/resources/templates/ecs/deploy.sh
+++ b/resources/templates/ecs/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning ECS resources"
 echo "FAIL" > deploy-status.txt
 npm install

--- a/resources/templates/ecs/deploy.sh
+++ b/resources/templates/ecs/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Provisioning ECS resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy FisStackEcs --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt
+

--- a/resources/templates/eks/cleanup.sh
+++ b/resources/templates/eks/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Cleaning up EKS resources"
+echo "FAIL" > cleanup-status.txt
+npm install
+npx cdk destroy FisStackEks --force
+echo "OK" > cleanup-status.txt
+

--- a/resources/templates/eks/deploy.sh
+++ b/resources/templates/eks/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning EKS resources"
 echo "FAIL" > deploy-status.txt
 npm install

--- a/resources/templates/eks/deploy.sh
+++ b/resources/templates/eks/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Provisioning EKS resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy FisStackEks --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt
+

--- a/resources/templates/goad-cdk/cleanup.sh
+++ b/resources/templates/goad-cdk/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Cleaning up load generator (goad) resources"
+echo "FAIL" > cleanup-status.txt
+npm install
+npx cdk destroy FisStackLoadGen --force
+echo "OK" > cleanup-status.txt
+

--- a/resources/templates/goad-cdk/deploy.sh
+++ b/resources/templates/goad-cdk/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning load generator (goad) resources"
 echo "FAIL" > deploy-status.txt
 npm install

--- a/resources/templates/goad-cdk/deploy.sh
+++ b/resources/templates/goad-cdk/deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Provisioning load generator (goad) resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy FisStackLoadGen --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt

--- a/resources/templates/rds/cleanup.sh
+++ b/resources/templates/rds/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Cleaning up vpc resources"
+echo "FAIL" > cleanup-status.txt
+npm install
+npx cdk destroy FisStackRdsAurora --force
+echo "OK" > cleanup-status.txt
+

--- a/resources/templates/rds/deploy.sh
+++ b/resources/templates/rds/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning vpc resources"
 echo "FAIL" > deploy-status.txt
 npm install

--- a/resources/templates/rds/deploy.sh
+++ b/resources/templates/rds/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Provisioning vpc resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy FisStackRdsAurora --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt
+

--- a/resources/templates/spot/cleanup.sh
+++ b/resources/templates/spot/cleanup.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 
-aws cloudformation delete-stack \
-    --stack-name FisSpotTest
-aws cloudformation wait stack-delete-complete \
-    --stack-name FisSpotTest
+echo "Cleaning up spot resources"
+echo "FAIL" > cleanup-status.txt
+
+STACK_NAME=$( aws cloudformation list-stacks --query "StackSummaries[?(StackName=='FisSpotTest')&&(StackStatus!='DELETE_COMPLETE')].StackName" --output text )
+if [ -n "${STACK_NAME}" ]; then
+    echo "... deleting"
+
+    aws cloudformation delete-stack \
+        --stack-name FisSpotTest
+    aws cloudformation wait stack-delete-complete \
+        --stack-name FisSpotTest
+else
+    echo "... no deletable stack found, skipping"
+fi
+
+echo "OK" > cleanup-status.txt

--- a/resources/templates/spot/deploy.sh
+++ b/resources/templates/spot/deploy.sh
@@ -2,6 +2,8 @@
 
 echo "Provisioning spot resources"
 
+echo "FAIL" > deploy-status.txt
+
 # Use subnet from workshop deploy
 SUBNET_ID=$( aws ec2 describe-subnets --query "Subnets[?Tags[?(Key=='aws-cdk:subnet-name') && (Value=='FisPriv') ]] | [0].SubnetId" --output text )
 
@@ -15,3 +17,5 @@ sam deploy \
   --no-fail-on-empty-changeset \
   --capabilities CAPABILITY_NAMED_IAM \
   --parameter-overrides "SubnetId=${SUBNET_ID} ImageId=${AMI_ID}"
+
+echo "OK" > deploy-status.txt

--- a/resources/templates/spot/deploy.sh
+++ b/resources/templates/spot/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning spot resources"
 
 echo "FAIL" > deploy-status.txt

--- a/resources/templates/vpc/cleanup.sh
+++ b/resources/templates/vpc/cleanup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Cleaning up vpc resources"
+echo "FAIL" > cleanup-status.txt
+npm install
+npx cdk destroy FisStackVpc --force
+echo "OK" > cleanup-status.txt
+

--- a/resources/templates/vpc/deploy.sh
+++ b/resources/templates/vpc/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+set -u
+set -o pipefail
+
 echo "Provisioning vpc resources"
 echo "FAIL" > deploy-status.txt
 npm install

--- a/resources/templates/vpc/deploy.sh
+++ b/resources/templates/vpc/deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Provisioning vpc resources"
+echo "FAIL" > deploy-status.txt
+npm install
+npx cdk deploy FisStackVpc --require-approval never --outputs-file outputs.json
+echo "OK" > deploy-status.txt
+

--- a/workshop/content/990_cleanup/_index.md
+++ b/workshop/content/990_cleanup/_index.md
@@ -9,10 +9,10 @@ To ensure you don't incur any further costs after the workshop, please follow th
 ## Manually
 
 * If you created the CI/CD stack and ran the pipeline, first start by deleting the insfrastructure provisioned by the pipeline: 
-  * Navigate to the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home?#/stacks?filteringStatus=active&filteringText=fisWorkshopDemo&viewNested=true&hideStacks=false) and find the stack named `fisWorkshopDemo` 
+  * Navigate to the [AWS CloudFormation console](https://console.aws.amazon.com/cloudformation/home?#/stacks?filteringStatus=active&filteringText=CicdStack&viewNested=true&hideStacks=false) and find the stack named `CicdStack` 
   * Select the stack 
   * Select "Delete" 
-* Once, the `fisWorkshopDemo` is deleted, following the same procedure as above, delete the `CicdStack` stack
+* Once, the `CicdStack` is deleted, following the same procedure as above, delete the `CicdStack` stack
   {{< img "delete-cicd.en.png" "Delete stack visual">}}
 * Following the same procedure as above, delete the following stacks
   * `FisStackEks`


### PR DESCRIPTION
*Issue #, if available:* Fixes #247

*Description of changes:*

* moved deploy/cleanup into individual component directories
  * changed create/update stack calls to deploy calls
  * added no fail on empty changeset options 
* updated `deploy-parallel.sh` / `cleanup-parallel.sh` to use individual components
* added summary result output to `deploy-parallel.sh` / `cleanup-parallel.sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
