### PR TITLE
Change to LTS version of node

### DIFF
--- a/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
+++ b/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
@@ -92,7 +92,8 @@ Copy/Paste the following code in your Cloud9 terminal (you can paste the whole b
 
 ```bash
 # Update to the latest stable release of npm and nodejs.
-nvm install stable 
+nvm install --lts
+nvm use --lts 
 
 # Install typescript
 npm install -g typescript


### PR DESCRIPTION
*Issue #, if available:* fixes #312

*Description of changes:*

* Amazon linux2 GLIBC version doesn't match latest npm stable requirements. Workaround by using LTS version of npm/node

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
