### PR TITLE
Rudpot/fix 315

### DIFF
--- a/resources/templates/cleanup-parallel.sh
+++ b/resources/templates/cleanup-parallel.sh
@@ -51,7 +51,10 @@ call_cleanup_script "asg-cdk" "ASG stack"
 # RDS/aurora stack uses CDK
 call_cleanup_script "rds" "RDS stack" 
 
-# Goad stack moved to CDK
+# Serverless controls using SAM
+call_cleanup_script "serverless" "Serverless stack" 
+
+# Access controls using CDK
 call_cleanup_script "access-controls" "Access controls stack" 
 
 # Goad stack moved to CDK

--- a/resources/templates/cleanup-parallel.sh
+++ b/resources/templates/cleanup-parallel.sh
@@ -92,6 +92,19 @@ echo "Deleting cdk state files ..."
 echo "Waiting for finish"
 wait
 
+# Manual cleanups of log groups
+
+(
+    for ii in \
+      /fis-workshop/fis-logs \
+      /fis-workshop/asg-error-log \
+      /fis-workshop/asg-access-log \
+    ; do
+      echo Deleting log group $ii
+      aws logs delete-log-group --log-group-name $ii >/dev/null 2>&1
+    done
+)
+
 EXIT_STATUS=0
 for substack in \
     ../code/cdk/cicd \

--- a/resources/templates/deploy-ee-codebuild/template.yaml
+++ b/resources/templates/deploy-ee-codebuild/template.yaml
@@ -108,8 +108,10 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.9
-                nodejs: 16
+                # Not ideal but if we pick explicit versions it fails in some regions
+                python: latest
+                # Not ideal but if we pick explicit versions it fails in some regions
+                nodejs: latest
               commands:
                 # Install sudo and jq for our installers
                 - yum install -y sudo jq

--- a/resources/templates/deploy-ee-codebuild/template.yaml
+++ b/resources/templates/deploy-ee-codebuild/template.yaml
@@ -107,18 +107,14 @@ Resources:
           version: 0.2
           phases:
             install:
+              runtime-versions:
+                python: 3.9
+                nodejs: 16
               commands:
                 # Install sudo and jq for our installers
                 - yum install -y sudo jq
                 # Update AWS CLI just in case
                 - pip install --upgrade awscli
-                ## - touch ~/.bashrc
-                # Install / update node for CDK
-                # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-up-node-on-ec2-instance.html
-                - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
-                - export NVM_DIR="$HOME/.nvm"
-                - '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"'
-                - '[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"'
                 # CDK stuffs
                 - npm install -g typescript
                 - npm install -g aws-cdk
@@ -127,7 +123,7 @@ Resources:
                 # Default outcome of build is FAILED
                 - export CUSTOM_RESOURCE_STATUS=FAILED
                 # Some debugging info 
-                - env
+                - env | sort 
                 - env | grep CUSTOM_RESOURCE_
                 - pwd
                 - df -h
@@ -137,6 +133,8 @@ Resources:
                 # Pull source - right now straight from github
                 # For EE we may want to update this to use the S3 bucket to avoid performance issues
                 - time git clone https://github.com/aws-samples/aws-fault-injection-simulator-workshop.git
+                # Optionally checkout branch for testing 
+                # - 'cd ${CODEBUILD_SRC_DIR}/aws-fault-injection-simulator-workshop/resources/templates && time git switch rudpot/fix-315'
                 # Build and deploy via CDK
                 - 'cd ${CODEBUILD_SRC_DIR}/aws-fault-injection-simulator-workshop/resources/templates && time ./deploy-parallel.sh $CUSTOM_RESOURCE_REQUEST'
                 - 'cd ${CODEBUILD_SRC_DIR}/aws-fault-injection-simulator-workshop/resources/templates && for ii in deploy-output*.txt; do echo --- $ii --- ; cat $ii; done'

--- a/resources/templates/deploy-parallel.sh
+++ b/resources/templates/deploy-parallel.sh
@@ -111,6 +111,7 @@ for substack in \
     vpc \
     goad-cdk \
     access-controls \
+    serverless \
     rds \
     asg-cdk \
     eks \

--- a/resources/templates/serverless/deploy.sh
+++ b/resources/templates/serverless/deploy.sh
@@ -11,6 +11,7 @@ echo "FAIL" > deploy-status.txt
 # Workaround to let sam deploy infer template by looking in build directory
 sam build \
   -t template.yaml \
+  --use-container \
 && \
 sam deploy \
   --stack-name FisStackServerless \

--- a/workshop/content/010_introduction/_index.en.md
+++ b/workshop/content/010_introduction/_index.en.md
@@ -1,6 +1,6 @@
 ---
 title: "Introduction"
-chapter: true
+chapter: false
 weight: 10
 services: true
 ---
@@ -21,9 +21,30 @@ Additionally, chaos engineering is about proving or disproving a hypothesis of h
 
 ## Duration
 
-When run in a prepared AWS account the core sections of the workshop will take between 1-2h. The whole workshop about 2-4h. Using the Amazon DevOps Guru section will require an additional 2-24h of wait time after the infrastructure has been configured.
+### Core sections
 
-When run in a customer account, deploying the workshop's core infrastructure will require an additional 45min. 
+For an introductory workshop we recommend the following core sections:
+
+* Baselining and Monitoring
+* Synthetic User Experience
+* First Experiment > Configuring Permissions
+* First Experiment > Experiment (Console)
+* AWS Systems Manager Integration > FIS SSM Send Command Setup
+* AWS Systems Manager Integration > Linux CPU Stress Experiment
+* AWS Systems Manager Integration > Working with SSM documents
+* AWS Systems Manager Integration > Optional - Windows CPU Stress Experiment
+* AWS Systems Manager Integration > FIS SSM Start Automation Setup
+* AWS Systems Manager Integration > SSM Additional resources
+* Databases > RDS DB Instance Reboot
+
+When run in a prepared AWS account these core sections of the workshop will take about 2-3h. When run in a customer account, deploying the workshop's core infrastructure will require an additional 45min. 
+
+### Additional sections
+
+All remaining sections are intended as independent modules that can be added based on customer need and interest. All sections require the roles created in
+
+* First Experiment > Configuring Permissions
+* AWS Systems Manager Integration > FIS SSM Start Automation Setup
 
 ## Cost
 

--- a/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
+++ b/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
@@ -20,7 +20,7 @@ Using the region selected in [**Region Selection**]({{< ref "030_region_selectio
 - Select **Create environment**
 - Name it `fisworkshop` and select **Next step**.
 - Since we only need to access our Cloud9 environment via web browser, please select the **Create a new no-ingress EC2 instance for environment (access via Systems Manager)** under the Environment Type.
-- Choose `t3.medium` for instance type, go through the wizard with the default values. Finally select **Create environment**
+- Select "Other Instance Types" and choose `t3.medium` (you can type to search) for instance type, go through the wizard with the default values. Finally select **Create environment**
 
 When it comes up, customize the environment by:
 

--- a/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
+++ b/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
@@ -20,7 +20,7 @@ Using the region selected in [**Region Selection**]({{< ref "030_region_selectio
 - Select **Create environment**
 - Name it `fisworkshop` and select **Next step**.
 - Since we only need to access our Cloud9 environment via web browser, please select the **Create a new no-ingress EC2 instance for environment (access via Systems Manager)** under the Environment Type.
-- Choose `t3.small` for instance type, go through the wizard with the default values. Finally select **Create environment**
+- Choose `t3.medium` for instance type, go through the wizard with the default values. Finally select **Create environment**
 
 When it comes up, customize the environment by:
 

--- a/workshop/content/020_starting_workshop/010_self_paced/050_create_stack/_index.en.md
+++ b/workshop/content/020_starting_workshop/010_self_paced/050_create_stack/_index.en.md
@@ -26,4 +26,25 @@ cd resources/templates
 ./deploy-parallel.sh
 ```
 
-It can take up to 30 minutes to complete.  
+{{% notice note %}}
+Instantiating all resources will take about 30 minutes. This might be a good time to read ahead at [**Baselining and Monitoring**]({{<ref "030_basic_content/010-baselining">}}) or go for coffee.
+{{% /notice %}}
+
+Review the deploy output. It should similar to this:
+
+```
+Substack vpc SUCCEEDED
+Substack goad-cdk SUCCEEDED
+Substack access-controls SUCCEEDED
+Substack serverless SUCCEEDED
+Substack rds SUCCEEDED
+Substack asg-cdk SUCCEEDED
+Substack eks SUCCEEDED
+Substack ecs SUCCEEDED
+Substack cpu-stress SUCCEEDED
+Substack api-failures SUCCEEDED
+Substack spot SUCCEEDED
+Overall install SUCCEEDED
+```
+
+If any of the substacks report as `FAILED` you can try to re-run the deployment script. If that still fails you can find some debugging information in files named `deploy-output.*.txt`.

--- a/workshop/content/990_cleanup/_index.en.md
+++ b/workshop/content/990_cleanup/_index.en.md
@@ -43,7 +43,7 @@ cd ~/environment
 ```bash
 cd aws-fault-injection-simulator-workshop
 cd resources/templates
-./cleanup.sh
+./cleanup-parallel.sh
 ```
 
 ## Retained resources


### PR DESCRIPTION
*Issue #, if available:* Fixes #315. Fixes #317

*Description of changes:*

* change SAM deploy to use container build and become agnostic to installed python version
* update workshop duration and wait times in a couple places
* fix cloud9 deploy description to use larger instance type to avoid out of memory issues
* fix deployment script to include serverless stack
* improve cleanup script to include serverless stack and to remove log groups
* change ee-deployment codebuild to use node from container - using latest because versioned doesn't work right

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
