### PR TITLE
Fix node/cdk installs

### DIFF
--- a/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
+++ b/workshop/content/020_starting_workshop/010_self_paced/040_create_workspace/_index.en.md
@@ -91,16 +91,15 @@ The instructions in this workshop assume you are using a bash shell in a linux-l
 Copy/Paste the following code in your Cloud9 terminal (you can paste the whole block at once).
 
 ```bash
-# Update to the latest stable release of npm and nodejs.
-nvm install --lts
-nvm use --lts 
+# Update to a supported version of node
+nvm install 16
+nvm use 16
 
 # Install typescript
 npm install -g typescript
 
 # Install CDK
-npm install -g aws-cdk
+npm update -g aws-cdk
 
 # Install the jq tool
-sudo yum install -y jq gettext
-```
+sudo yum install -y jq gettext```


### PR DESCRIPTION
*Issue #, if available:* Fixes #408. 

*Description of changes:*

* downgraded node install from `--lts` (18) to explicit major version (16) to support Amazon linux GLIBC limitation
* changed CDK install to use `update` instead of `install` to suppress error message

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
