### PR TITLE
Update matrix builds to run across multiple accounts

### DIFF
--- a/.github/workflows/aws_cleanup_multi_account.yml
+++ b/.github/workflows/aws_cleanup_multi_account.yml
@@ -31,7 +31,7 @@ on:
         type: string
         default: "096785028781"
         
-concurrency: FisWorkshopBuildDestroy-{{ inputs.account_id }}
+# concurrency: FisWorkshopBuildDestroy-{{ inputs.account_id }}
 
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/.github/workflows/aws_deploy_multi_account.yml
+++ b/.github/workflows/aws_deploy_multi_account.yml
@@ -30,7 +30,7 @@ on:
         type: string
         default: "096785028781"
         
-concurrency: FisWorkshopBuildDestroy-{{ inputs.account_id }}
+# concurrency: FisWorkshopBuildDestroy-{{ inputs.account_id }}
 
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/.github/workflows/aws_matrix_multi_account.yml
+++ b/.github/workflows/aws_matrix_multi_account.yml
@@ -74,3 +74,4 @@ jobs:
     with:
       region: ${{ matrix.mappings.region }}
       account_id: ${{ matrix.mappings.account_id }}
+      concurrency: run-${{ matrix.mappings.account_id }}

--- a/.github/workflows/aws_matrix_multi_account.yml
+++ b/.github/workflows/aws_matrix_multi_account.yml
@@ -74,4 +74,4 @@ jobs:
     with:
       region: ${{ matrix.mappings.region }}
       account_id: ${{ matrix.mappings.account_id }}
-      concurrency: run-${{ matrix.mappings.account_id }}
+    concurrency: run-${{ matrix.mappings.account_id }}

--- a/.github/workflows/aws_matrix_multi_account.yml
+++ b/.github/workflows/aws_matrix_multi_account.yml
@@ -46,7 +46,7 @@ jobs:
         #                     us-gov-west-1                   
         # rudpot+workshoptest-us-west-1       523483904916  rudpot+workshoptest-us-west-1
         # rudpot+workshoptest-us-west-2       532417486699  rudpot+workshoptest-us-west-2
-        region: # From https://docs.aws.amazon.com/general/latest/gr/fis.html
+        mappings: # From https://docs.aws.amazon.com/general/latest/gr/fis.html
           # - { af-south-1    ,              } ## Africa (Cape Town) # opt-in
           - { region: ap-east-1     , account_id: "834763257438" } # Asia Pacific (Hong Kong)
           - { region: ap-northeast-1, account_id: "624272761222" } # Asia Pacific (Tokyo)
@@ -72,5 +72,5 @@ jobs:
 
     uses: ./.github/workflows/aws_region_test_multi_account.yml
     with:
-      region: ${{ matrix.region }}
-      account_id: ${{ matrix.account_id }}
+      region: ${{ matrix.mappings.region }}
+      account_id: ${{ matrix.mappings.account_id }}

--- a/.github/workflows/aws_matrix_multi_account.yml
+++ b/.github/workflows/aws_matrix_multi_account.yml
@@ -13,7 +13,7 @@ on:
   # Allows this workflow to be called
   workflow_call:
         
-concurrency: FisWorkshopBuildDestroyMatrixMultiAccount
+# concurrency: FisWorkshopBuildDestroyMatrixMultiAccount
 
 run-name: AwsMatrix
 

--- a/.github/workflows/aws_matrix_multi_account.yml
+++ b/.github/workflows/aws_matrix_multi_account.yml
@@ -23,7 +23,6 @@ jobs:
   matrix-deploy:
     strategy:
       fail-fast: false
-      max-parallel: 1 # we should create 20 isengard accounts and run fully parallel instead
       matrix:
         #                     af-south-1                   
         # rudpot+workshoptest-ap-east-1       834763257438  rudpot+workshoptest-ap-east-1

--- a/.github/workflows/aws_matrix_multi_account.yml
+++ b/.github/workflows/aws_matrix_multi_account.yml
@@ -13,7 +13,7 @@ on:
   # Allows this workflow to be called
   workflow_call:
         
-concurrency: FisWorkshopBuildDestroyMatrix
+concurrency: FisWorkshopBuildDestroyMatrixMultiAccount
 
 run-name: AwsMatrix
 

--- a/.github/workflows/aws_region_test_multi_account.yml
+++ b/.github/workflows/aws_region_test_multi_account.yml
@@ -31,7 +31,7 @@ on:
         type: string
         default: "096785028781"
         
-concurrency: FisWorkshopBuildRegionTest-${{ inputs.account_id }}
+# concurrency: FisWorkshopBuildRegionTest-${{ inputs.account_id }}
 
 run-name: RegionTest in ${{ inputs.region }} / ${{ inputs.account_id }}
 

--- a/.github/workflows/aws_region_test_multi_account.yml
+++ b/.github/workflows/aws_region_test_multi_account.yml
@@ -39,7 +39,7 @@ run-name: RegionTest in ${{ inputs.region }} / ${{ inputs.account_id }}
 
 jobs:
   region-deploy:
-    uses: ./.github/workflows/aws_deploy.yml
+    uses: ./.github/workflows/aws_deploy_multi_account.yml
     with:
       region: ${{ inputs.region }}
       account_id: ${{ inputs.account_id }}
@@ -47,7 +47,7 @@ jobs:
   region-cleanup:
     needs: region-deploy
     if: ${{ always() }}
-    uses: ./.github/workflows/aws_cleanup.yml
+    uses: ./.github/workflows/aws_cleanup_multi_account.yml
     with:
       region: ${{ inputs.region }}
       account_id: ${{ inputs.account_id }}

--- a/.github/workflows/aws_region_test_multi_account.yml
+++ b/.github/workflows/aws_region_test_multi_account.yml
@@ -31,9 +31,9 @@ on:
         type: string
         default: "096785028781"
         
-concurrency: FisWorkshopBuildRegionTest
+concurrency: FisWorkshopBuildRegionTest-${{ inputs.account_id }}
 
-run-name: RegionTest in ${{ inputs.region }}
+run-name: RegionTest in ${{ inputs.region }} / ${{ inputs.account_id }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Update matrix build

Validated the the matrix build now works, fully parallel, and utilizing all accounts. For some reason OIDC in ap-east-1 is failing - TBD whether to remove that region from workshop or figure out how to do OIDC auth there. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
