### PR TITLE
Update _index.en.md

### DIFF
--- a/workshop/content/030_basic_content/076_api_faults/020_api_errors/_index.en.md
+++ b/workshop/content/030_basic_content/076_api_faults/020_api_errors/_index.en.md
@@ -135,7 +135,7 @@ In [**FIS**](https://console.aws.amazon.com/fis/home) ensure the experiment is s
 When the experiment begins running issue a new curl request to the `/terminate` path, but this time with a `POST` action.  HTTP `POST` methods are usually used for mutating actions.  
 
 ```bash
-curl -X POST curl ${TERMINATION_URL}
+curl -X POST ${TERMINATION_URL}
 ```
 
 Even with the experiment running you should receive a response that looks similar to


### PR DESCRIPTION
Line 138 has double curl in the code section here.

*Issue #, if available:*
Code section is showing double curl like here
curl -X POST curl ${TERMINATION_URL}

*Description of changes:*
I have removed extra curl.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
