### PR TITLE
added AWS_DEFAULT_REGION

### DIFF
--- a/resources/templates/deploy-ee-codebuild/template-s3.yaml
+++ b/resources/templates/deploy-ee-codebuild/template-s3.yaml
@@ -164,6 +164,10 @@ Resources:
                 - time aws s3 cp s3://${EE_ASSETS_BUCKET}/${EE_ASSETS_BUCKET_KEY_PREFIX}resources.zip ${CODEBUILD_SRC_DIR}/aws-fault-injection-simulator-workshop/resources.zip
                 - 'cd ${CODEBUILD_SRC_DIR}/aws-fault-injection-simulator-workshop/ && unzip resources.zip'
                 # Build and deploy via CDK
+                - echo "this is AWS DEFAULT Region: ${AWS_DEFAULT_REGION}"
+                - echo "this is AWS Region: ${AWS_REGION}"
+                - export AWS_DEFAULT_REGION=$AWS_REGION
+                - echo "this is AWS DEFAULT Region: ${AWS_DEFAULT_REGION}"
                 - 'cd ${CODEBUILD_SRC_DIR}/aws-fault-injection-simulator-workshop/resources/templates && time ./deploy-parallel.sh $CUSTOM_RESOURCE_REQUEST'
                 # We didn't fail so reset build outcome to SUCCESS
                 - export CUSTOM_RESOURCE_STATUS=SUCCESS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Build seems to break for serverless and SAM because of the AWS DEFAULT Region missing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
